### PR TITLE
devDependencies: remove 'fs'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"string-width": "^2.1.1"
 	},
 	"devDependencies": {
-		"fs": "^0.0.1-security",
 		"nodemon": "^2.0.7"
 	}
 }


### PR DESCRIPTION
https://www.npmjs.com/package/fs is not a package and contains nothing.
It's a placeholder to prevent malicious users from claiming this package name.

Thus, it's not necessary to keep it.