### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
 		"mathjs": "^9.4.3",
 		"node-fetch": "^2.6.1",
 		"quick.db": "^7.1.3",
-		"string-width": "^2.1.1"
+		"string-width": "^2.1.1",
+		"cheerio": "^1.0.0-rc.10",
+		"axios": "^0.22.0"	
 	},
 	"devDependencies": {
 		"@weky/inlinereply": "^0.0.0",
-		"axios": "^0.21.1",
-		"cheerio": "^1.0.0-rc.10",
 		"nodemon": "^2.0.12"
 	}
 }


### PR DESCRIPTION
Hopefully, this should fix an issue where it doesn't install axios and cheerio on `npm install weky` (`Error: Cannot find module 'axios'` etc), since it is required for the package and it shouldn't be listed as a devDep. 
And a small update bump on axios.